### PR TITLE
Feat - Slack app to get URL's

### DIFF
--- a/slack_app/URLGetter.py
+++ b/slack_app/URLGetter.py
@@ -1,0 +1,51 @@
+from slackClient import SlackClient
+from datetime import datetime
+from urlextract import URLExtract
+import tldextract
+import json
+
+def getURLDomains(text):
+    extractor = URLExtract()
+    urls = extractor.find_urls(text)
+    domains_list = []
+    for url in urls:
+        domain = tldextract.extract(url).domain
+        domains_list.append(domain)
+    return domains_list
+
+def writeJSON(file_name, object_instance):
+    f = open(file_name+".json", "w")
+    f.write(json.dumps(object_instance))
+    f.close()
+
+def getDomainsByChannel(key, jsonName):
+    client = SlackClient(key)
+    channels = client.getChannels(True)
+    result = {}
+    for channel in channels:
+        result[channel["id"]] = {}
+        result[channel["id"]]["name"] = channel["name"]
+        result[channel["id"]]["domains"] = {}
+        print("Getting " + channel["name"] + "(" + channel["id"] + ") channel's messages.", end="")
+        messages = client.getChannelHistory(channel["id"])
+        print(".",end="")
+        for message in messages:
+            date = datetime.utcfromtimestamp(float(message["ts"])).strftime('%Y-%m-%d %H:%M:%S')
+            day = date.split(" ")[0]
+            domains = result[channel["id"]]["domains"]
+            newDomains = getURLDomains(message["text"])
+            if len(newDomains) > 0:
+                if day not in domains:
+                    domains[day] = {}
+                for domain in newDomains:
+                    if domain not in domains[day]:
+                        domains[day][domain] = 0
+                    domains[day][domain] += 1
+        print("DONE")
+    writeJSON(jsonName, result)
+    
+today = str(datetime.now()).split()[0]
+slack_api_key = API_KEY_HERE
+jsonName = "allChannels_"+today
+
+getDomainsByChannel(slack_api_key, jsonName)

--- a/slack_app/URLGetter.py
+++ b/slack_app/URLGetter.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from urlextract import URLExtract
 import tldextract
 import json
+import os
 
 def getURLDomains(text):
     extractor = URLExtract()
@@ -45,7 +46,9 @@ def getDomainsByChannel(key, jsonName):
     writeJSON(jsonName, result)
     
 today = str(datetime.now()).split()[0]
-slack_api_key = API_KEY_HERE
-jsonName = "allChannels_"+today
-
-getDomainsByChannel(slack_api_key, jsonName)
+slack_api_key = os.environ.get("SLACK_API_KEY")
+if slack_api_key:
+    jsonName = "allChannels_"+today
+    getDomainsByChannel(slack_api_key, jsonName)
+else:
+    print("Error: Be sure to set the api key in an environment variable called SLACK_API_KEY")

--- a/slack_app/requirements.txt
+++ b/slack_app/requirements.txt
@@ -1,0 +1,3 @@
+tldextract
+urlextract
+slackclient

--- a/slack_app/slackClient.py
+++ b/slack_app/slackClient.py
@@ -1,0 +1,52 @@
+import slack
+class SlackClient:
+    def __init__(self, token):
+        self.__client = slack.WebClient(token=token)
+    
+    # Given the list of channels, return only the PUBLIC channels' ids and names
+    def clean_channels_info(self, channels):
+        newChannels = []
+        for channel in channels:
+            if not channel["is_private"]:
+                newChannel = {}
+                newChannel["id"]=channel["id"]
+                newChannel["name"]=channel["name"]
+                newChannels.append(newChannel)
+        return newChannels
+
+    # Print only the name and the Id of the channels in the given list
+    def printChannels(self, channels):
+        print("Available channels:")
+        for channel in channels:
+            print(f'\t{channel["name"]} ({channel["id"]})')
+
+    # Get the channels list and clean it.
+    def getChannels(self, show=False):
+        response = self.__client.channels_list()
+        if response["ok"]:
+            channels = response["channels"]
+            channels = self.clean_channels_info(channels)
+            if show:
+                self.printChannels(channels)
+            return channels
+        print("Error: Couldn't get channels")
+        return None
+
+    def clean_messages(self, messages):
+        newMessages = []
+        for message in messages:
+            newMessage = {}
+            newMessage["text"] = message["text"]
+            newMessage["ts"] = message["ts"]
+            newMessages.append(newMessage)
+        return newMessages
+
+    # Given a channel ID, return the channel's history of messages
+    def getChannelHistory(self, channel_id):
+        history_response = self.__client.channels_history(channel=channel_id)
+        if history_response["ok"]:
+            messages = history_response["messages"]
+            messages = self.clean_messages(messages)
+            return messages
+        print("Error: Couldn't get channel history")
+        return None


### PR DESCRIPTION
#### What does this PR do?

Add scripts that get domains from urls in messages from a slack channel.
A module allows request from the slack api to get messages from all
channels, a scripts parses the information and creates a JSON with all
the channels and the count of domains mentioned in the messages, the
domains are grouped by day. Also added a text document that contains the
names of all the required python libraries.

#### Where should the reviewer start?

Read the URLGetter.py script and follow the code from there.

#### How should this be manually tested?
1.- Get a slack api token and put in the URLGetter.py script
2.- Run URLGetter.py script `python URLGetter.py`
3.- Check the JSON file that was created

#### Any background context you want to provide?
This feature is to get information about what web pages are mentioned more in a slack workspace or channel. This information is going to be used to focus the webpage parsing of the chrome extension in the most mentioned web pages.

#### What are the relevant tickets?

Fixes #4 

#### Screenshots
Not available

#### Questions
Is there a better way to parse the messages into a JSON file?
Does it need to handle errors? Remember that we are making API requests
Does it need more testing?

#### Checklist
- [X] I added the necessary documentation, if appropriate.
- [X] I added tests to prove that my fix is effective or my feature works.
- [X] I reviewed existing Pull Requests before submitting mine.
