### PR TITLE
Feat - Script to extract metadata

### DIFF
--- a/extractor.py
+++ b/extractor.py
@@ -1,0 +1,29 @@
+# pip install extruct
+import extruct
+import requests
+from w3lib.html import get_base_url
+import json
+
+#Given a url obtain metadata in JSON format from the website using extruct library 
+#If writedata==True write a JSON file with the data
+#Returns a dictionary with the metadata form the url
+def extractJSON(url, write_data=False):
+    r = requests.get(url)
+    base_url = get_base_url(r.text, r.url)
+    data = extruct.extract(r.text, base_url=base_url)["json-ld"]
+    if len(data) > 0:
+        if write_data:
+            with open('last_data.json', 'w') as outfile:
+                json.dump(data[0], outfile)
+        return data[0]
+    return []
+
+#Given a url obtain only the keywords
+#Returns a list with the keywords found in the url
+def getKeywords(url):
+    data = extractJSON(url, True)
+    return data["keywords"]
+
+url = 'https://medium.com/@felipegaiacharly/live-reloading-and-lazy-loading-for-micro-frontends-using-ara-framework-707ccb0f1960'
+keywords = getKeywords(url)
+print(keywords)


### PR DESCRIPTION
#### What does this PR do?

Add script that uses extruct library to get metadata of a webpage in JSON format. It also has a method to just get the keywords from the url.

#### Where should the reviewer start?

Read the URLGetter.py script and follow the code from there.

#### How should this be manually tested?

1.- Install the extruct library `pip install extruct`
2.- Change the url in the script with any url you want
3.- Run extractor.py script `python extractor.py`
4.- Read the keywords printed in the console

#### Any background context you want to provide?

The feature is going to help us create the base of a general keyword extractor to categorize domains, blogs, videos or any content and make recommendations based on that.

#### What are the relevant tickets?

Fixes #6 

#### Screenshots

Not available

#### Questions

Is it just me or it takes a while to get the keywords?

#### Checklist

- [x] I added the necessary documentation, if appropriate.
- [x] I added tests to prove that my fix is effective or my feature works.
- [x] I reviewed existing Pull Requests before submitting mine.